### PR TITLE
Add labels to dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Elysia Backend + React Native + Next.js",
 	"workspaces": ["apps/*", "packages/*"],
 	"scripts": {
-		"dev": "concurrently \"cd apps/backend && bun dev\" \"cd apps/mobile && bun ios\" \"cd apps/web && bun --bun run dev\"",
+		"dev": "concurrently -n 'backend,mobile,web' -c '#007755,#2f6da3,#550077' 'cd apps/backend && bun dev' 'cd apps/mobile && bun ios' 'cd apps/web && bun --bun run dev'",
 		"typecheck": "bunx --bun tsc",
 		"lint": "biome lint .",
 		"lint:fix": "biome lint --apply .",


### PR DESCRIPTION
Adds labels to the dev script to make it easy to identify which package logs are coming from.
![Screenshot 2024-08-12 at 7 54 23 AM](https://github.com/user-attachments/assets/9269baf2-42b9-4eeb-8dcf-3ac96cfd222e)
